### PR TITLE
Adds support to select the default aws Region

### DIFF
--- a/src/cache/s3.rs
+++ b/src/cache/s3.rs
@@ -13,7 +13,7 @@ use rusoto_core::signature::SignedRequestPayload::Stream;
 use std::ptr::null;
 
 pub async fn download_from_s3(filename: String,prefix: String, bucket: String) -> Result<(),Box<dyn std::error::Error>>{
-    let s3_client = S3Client::new(Region::UsWest1);
+    let s3_client = S3Client::new(Region::default());
 
     let f_name = { filename.clone() };
     let path_str = f_name.split("/").last().unwrap_or("");
@@ -37,7 +37,7 @@ pub async fn download_from_s3(filename: String,prefix: String, bucket: String) -
 }
 
 pub async fn upload(filename: String,prefix:String, bucket:String) -> Result<(),Box<dyn std::error::Error>>{
-    let s3_client = S3Client::new(Region::UsWest1);
+    let s3_client = S3Client::new(Region::default());
     let mut buffer = Vec::new();
     let f_name = { filename.clone() };
     let path_str = f_name.split("/").last().unwrap().to_string();


### PR DESCRIPTION
This PR addresses Issue 7 (https://github.com/summerlabs/punic/issues/7)

**Further Documentation**
https://rusoto.github.io/rusoto/rusoto_core/region/enum.Region.html

**Changes Made**
Updated s3.rs to use the Region::default() instead of the hardcoded uswest1. 

**Improvements**
This will provide greater flexibility for users and also ensure that the region can be tweaked externally via the aws config file. This addresses the issue we were seeing where files were not being uploaded to AWS S3.

Please can we merge this and release a new version 0.8? 

Thank you to all involved in this project it is going to be extremely useful for our team :) 